### PR TITLE
feat: migrate to Typefully API v2

### DIFF
--- a/apps/plugin/src/app/constants.ts
+++ b/apps/plugin/src/app/constants.ts
@@ -4,12 +4,13 @@
 export const NOTICE_TIMEOUT = 5000;
 
 /**
- * Typefully API URL
- * Reference: https://support.typefully.com/en/articles/8718287-typefully-api
+ * Typefully API URL (v2)
+ * Reference: https://typefully.com/docs/api
  */
-export const TYPEFULLY_API_URL = 'https://api.typefully.com/v1';
+export const TYPEFULLY_API_URL = 'https://api.typefully.com/v2';
 
-export const TYPEFULLY_API_DRAFTS = '/drafts/';
+export const TYPEFULLY_API_SOCIAL_SETS = '/social-sets';
+export const TYPEFULLY_API_DRAFTS = '/drafts';
 
 export const MSG_API_KEY_CONFIGURATION_REQUIRED =
   'Please configure the Typefully plugin to provide a valid API key';

--- a/apps/plugin/src/app/settingTab/index.ts
+++ b/apps/plugin/src/app/settingTab/index.ts
@@ -18,6 +18,7 @@ export class SettingsTab extends PluginSettingTab {
     containerEl.empty();
 
     this.renderApiKey(containerEl);
+    this.renderSocialSetId(containerEl);
     this.renderAutoRetweet(containerEl);
     this.renderAutoPlug(containerEl);
     this.renderThreadify(containerEl);
@@ -43,6 +44,29 @@ export class SettingsTab extends PluginSettingTab {
           await this.plugin.saveSettings();
         });
     });
+  }
+
+  renderSocialSetId(containerEl: HTMLElement) {
+    new Setting(containerEl)
+      .setName('Social Set ID')
+      .setDesc(
+        'Optional: Your Typefully Social Set ID. Leave empty to auto-detect. Find it in Typefully Settings → API with Development mode enabled.'
+      )
+      .addText((text) => {
+        text
+          .setPlaceholder('Auto-detect')
+          .setValue(this.plugin.settings.socialSetId)
+          .onChange(async (newValue) => {
+            log(`Social Set ID set to: `, 'debug', newValue);
+            this.plugin.settings = produce(
+              this.plugin.settings,
+              (draft: Draft<PluginSettings>) => {
+                draft.socialSetId = newValue;
+              }
+            );
+            await this.plugin.saveSettings();
+          });
+      });
   }
 
   renderAutoRetweet(containerEl: HTMLElement) {

--- a/apps/plugin/src/app/types/plugin-settings.intf.ts
+++ b/apps/plugin/src/app/types/plugin-settings.intf.ts
@@ -1,5 +1,6 @@
 export interface PluginSettings {
   apiKey: string;
+  socialSetId: string;
   autoRetweet: boolean;
   autoPlug: boolean;
   threadify: boolean;
@@ -9,6 +10,7 @@ export interface PluginSettings {
 
 export const DEFAULT_SETTINGS: PluginSettings = {
   apiKey: '',
+  socialSetId: '',
   autoRetweet: false,
   autoPlug: false,
   threadify: false,

--- a/apps/plugin/src/app/types/typefully-draft-contents.intf.ts
+++ b/apps/plugin/src/app/types/typefully-draft-contents.intf.ts
@@ -1,25 +1,51 @@
 /**
- * Reference: https://support.typefully.com/en/articles/8718287-typefully-api
+ * Reference: https://typefully.com/docs/api
+ * Typefully API v2 Draft Contents
  */
 export interface TypefullyDraftContents {
-  /**
-   * You can split into multiple tweets by adding 4 consecutive newlines between tweets in the content.
-   */
-  content: string;
-  /**
-   * Content will be automatically split into multiple tweets
-   */
-  threadify: boolean;
-  /**
-   * Can either be an ISO formatted date (e.g.:2022-06-13T11:13:31.662Z) or next-free-slot
-   */
-  'schedule-date'?: string | 'next-free-slot';
-  /**
-   * If true, the post will have an AutoRT enabled, according to the one set on Typefully for the account.
-   */
-  auto_retweet_enabled: boolean;
-  /**
-   * If true, the post will have an AutoPlug enabled, according to the one set on Typefully for the account.
-   */
-  auto_plug_enabled: boolean;
+  platforms: TypefullyPlatforms;
+  draft_title?: string;
+  tags?: string[];
+  share?: boolean;
+  publish_at?: string | 'now' | 'next-free-slot';
+}
+
+export interface TypefullyPlatforms {
+  x?: TypefullyPlatformConfig;
+  linkedin?: TypefullyPlatformConfig;
+  threads?: TypefullyPlatformConfig;
+  bluesky?: TypefullyPlatformConfig;
+  mastodon?: TypefullyPlatformConfig;
+}
+
+export interface TypefullyPlatformConfig {
+  enabled: boolean;
+  posts: TypefullyPost[];
+  settings?: TypefullyXSettings;
+}
+
+export interface TypefullyPost {
+  text: string;
+  media_ids?: string[];
+}
+
+export interface TypefullyXSettings {
+  reply_to_url?: string;
+  community_id?: string;
+  share_with_followers?: boolean;
+}
+
+/**
+ * Social Set (account) response
+ */
+export interface TypefullySocialSet {
+  id: number;
+  username: string;
+  name: string;
+  profile_image_url: string;
+}
+
+export interface TypefullySocialSetsResponse {
+  results: TypefullySocialSet[];
+  count: number;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "PLUGIN_NAME",
+  "name": "obsidian-typefully",
   "version": "1.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "PLUGIN_NAME",
+      "name": "obsidian-typefully",
       "version": "1.2.10",
       "license": "MIT",
       "dependencies": {
@@ -8608,6 +8608,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
## Summary
Migrated the Obsidian Typefully plugin from API v1 to v2.

## Changes
- Updated API endpoint from `/v1/drafts` to `/v2/social-sets/{id}/drafts`
- Changed auth header from `X-API-KEY` to `Authorization: Bearer`
- Updated draft content format to use `platforms` object with `posts` array
- Added `socialSetId` setting (optional - auto-detects if not set)
- Added `fetchSocialSets` function for auto-detection
- Updated response handling for v2 format
- Threadify now splits content into multiple post objects

## Why
Typefully migrated to API v2. The v1 API returns 404/invalid token errors.

## Testing Needed
- [ ] Test with valid API key
- [ ] Test social set auto-detection
- [ ] Test threadify (multi-post)
- [ ] Test auto-schedule